### PR TITLE
ensure correct mime type

### DIFF
--- a/sitewide-metadata.json.php
+++ b/sitewide-metadata.json.php
@@ -1,4 +1,5 @@
 <?php
+header('Content-type: application/json');
 $issuer = 'http' . (isset($_SERVER['HTTPS']) ? 's' : '') . '://' . $_SERVER['HTTP_HOST'];
 $meta = [
 	"issuer" => $issuer,


### PR DESCRIPTION
If this were a static *.json, then Apache HTTPd would pick up the mime type correctly; however, since this is dynamic with PHP, the mime type has to manually be flagged.