### PR TITLE
final determination on Require statements in config

### DIFF
--- a/selfauth.conf
+++ b/selfauth.conf
@@ -1,19 +1,17 @@
 
 AliasMatch ^/selfauth/setup$ /usr/local/src/mindie-idp/selfauth/setup.php
 AliasMatch ^/selfauth/index$ /usr/local/src/mindie-idp/selfauth/index.php
-<FilesMatch /usr/local/src/mindie-idp/selfauth/(setup|index).php$ >
-	<RequireAll>
+<Directory /usr/local/src/mindie-idp/selfauth/>
+	<FilesMatch (setup|index).php$ >
 		Require all granted
-	</RequireAll>
-</FilesMatch>
+	</FilesMatch>
+</Directory>
 <Location /selfauth/>
 	SetEnv SELFAUTH_MULTIUSER true
 	SetEnv SELFAUTH_CONFIG /var/lib/selfauth
 </Location>
 <Directory /var/lib/selfauth/ >
-	<RequireAll>
-		Require all denied
-	</RequireAll>
+	Require all denied
 </Directory>
 
 # vim: syntax=apache ts=4 sw=4 sts=4 sr noet


### PR DESCRIPTION
This declaration is coming from a fresh install.
`<FilesMatch>` did not work and would prefer not `<Location>` so that it can be overridden easier. That being said, Location may need to be granted if other config denies the webspace path.

The removal for `<RequireAll>` is due to Apache joining each file's overridding config in a `<RequireAny>`, effectively making this redundant.