### PR TITLE
Token Endpoint WITHOUT Scopes

### DIFF
--- a/selfauth/README.md
+++ b/selfauth/README.md
@@ -26,7 +26,8 @@ License: [MIT](MIT-LICENSE.md)
 - [support discovery](https://github.com/Inklings-io/selfauth/pull/55)
 - [multi-user support](https://github.com/Inklings-io/selfauth/pull/57) --> now [DB fix](https://github.com/carrvo/mindie-idp/issues/15)
 - [client discovery](https://github.com/Inklings-io/selfauth/pull/59)
-- auto-click for configured anonymous user (lines 428-435)
+- auto-click for configured anonymous user (lines 458-465)
+- enforce some scope returned (lines 246-249)
 - additional logging statements
 
 # Selfauth

--- a/selfauth/index.php
+++ b/selfauth/index.php
@@ -243,6 +243,10 @@ if ($code !== null) {
     if ($code_parts[2] !== '') {
         $response['scope'] = base64_url_decode($code_parts[2]);
     }
+    else {
+        # MinToken requires there to be *some* scope as a part of ensuring a valid reply
+        $response['scope'] = 'none';
+    }
 
     // Accept header
     $accept_header = '*/*';


### PR DESCRIPTION
MinToken requires *some* scope when it passes off auth to SelfAuth and processes the result (adding token). IndieAuth-Client-php does not, by default, use the token endpoint when there are no scopes; however, this may be outdated and other tools (such as IndieLogin.com) do. This change makes it compatible with these tools.